### PR TITLE
FIX: Data formatting unconfirmed operations

### DIFF
--- a/server/cmd/server/.env
+++ b/server/cmd/server/.env
@@ -2,7 +2,7 @@
 GRPC_PORT="8085"
 # Multiversx main chain wallet to send bridge transactions.
 # Possible files: pem/json
-WALLET_PATH="/home/ubuntu/wallet.pem"
+WALLET_PATH="wallet.pem"
 # Wallet's password (e.g.: json password encrypted wallet).
 # Can be left empty for pem wallets
 WALLET_PASSWORD=""
@@ -18,5 +18,8 @@ MAX_RETRIES_SECONDS_WAIT_NONCE=60
 # One should use the same certificate for clients as well.
 # You can generate your own certificate files with the binary found in
 # this repository in cert/cmd/cert
-CERT_FILE="/home/ubuntu/MultiversX/testnet/node/config/certificate.crt"
-CERT_PK_FILE="/home/ubuntu/MultiversX/testnet/node/config/private_key.pem"
+CERT_FILE="certificate.crt"
+CERT_PK_FILE="private_key.pem"
+# Hasher type used for bridge operation hashing. Should be compatible with the one
+# from sovereign nodes and bridge contract
+HASHER="sha256"

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -45,6 +45,7 @@ const (
 	envMaxRetriesWaitNonce = "MAX_RETRIES_SECONDS_WAIT_NONCE"
 	envCertFile            = "CERT_FILE"
 	envCertPkFile          = "CERT_PK_FILE"
+	envHasher              = "HASHER"
 )
 
 func main() {
@@ -146,6 +147,7 @@ func loadConfig() (*config.ServerConfig, error) {
 	maxRetriesWaitNonceStr := os.Getenv(envMaxRetriesWaitNonce)
 	certFile := os.Getenv(envCertFile)
 	certPkFile := os.Getenv(envCertPkFile)
+	hasher := os.Getenv(envHasher)
 
 	maxRetriesWaitNonce, err := strconv.Atoi(maxRetriesWaitNonceStr)
 	if err != nil {
@@ -157,6 +159,7 @@ func loadConfig() (*config.ServerConfig, error) {
 	log.Info("loaded config", "esdtSafeSCAddress", esdtSafeSCAddress)
 	log.Info("loaded config", "proxy", proxy)
 	log.Info("loaded config", "maxRetriesWaitNonce", maxRetriesWaitNonce)
+	log.Info("loaded config", "hasher", hasher)
 
 	log.Info("loaded config", "certificate file", certFile)
 	log.Info("loaded config", "certificate pk", certPkFile)
@@ -172,6 +175,7 @@ func loadConfig() (*config.ServerConfig, error) {
 			EsdtSafeSCAddress:          esdtSafeSCAddress,
 			Proxy:                      proxy,
 			MaxRetriesSecondsWaitNonce: maxRetriesWaitNonce,
+			Hasher:                     hasher,
 		},
 		CertificateConfig: cert.FileCfg{
 			CertFile: certFile,

--- a/server/txSender/config.go
+++ b/server/txSender/config.go
@@ -12,4 +12,5 @@ type TxSenderConfig struct {
 	EsdtSafeSCAddress          string
 	Proxy                      string
 	MaxRetriesSecondsWaitNonce int
+	Hasher                     string
 }

--- a/server/txSender/dataFormatter.go
+++ b/server/txSender/dataFormatter.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"encoding/hex"
 
+	"github.com/multiversx/mx-chain-core-go/core"
+	"github.com/multiversx/mx-chain-core-go/core/check"
 	"github.com/multiversx/mx-chain-core-go/data/sovereign"
 	"github.com/multiversx/mx-chain-core-go/hashing"
 )
@@ -18,8 +20,14 @@ type dataFormatter struct {
 }
 
 // NewDataFormatter creates a sovereign bridge tx data formatter
-func NewDataFormatter() *dataFormatter {
-	return &dataFormatter{}
+func NewDataFormatter(hasher hashing.Hasher) (*dataFormatter, error) {
+	if check.IfNil(hasher) {
+		return nil, core.ErrNilHasher
+	}
+
+	return &dataFormatter{
+		hasher: hasher,
+	}, nil
 }
 
 // CreateTxsData creates txs data for bridge operations
@@ -34,7 +42,7 @@ func (df *dataFormatter) CreateTxsData(data *sovereign.BridgeOperations) [][]byt
 
 		registerBridgeOpData := df.createRegisterBridgeOperationsData(bridgeData)
 		if len(registerBridgeOpData) != 0 {
-			txsData = append(txsData, df.createRegisterBridgeOperationsData(bridgeData))
+			txsData = append(txsData, registerBridgeOpData)
 		}
 
 		txsData = append(txsData, createBridgeOperationsData(bridgeData.Hash, bridgeData.OutGoingOperations)...)

--- a/server/txSender/factory.go
+++ b/server/txSender/factory.go
@@ -3,6 +3,7 @@ package txSender
 import (
 	"time"
 
+	"github.com/multiversx/mx-chain-core-go/hashing/factory"
 	"github.com/multiversx/mx-sdk-go/blockchain"
 	"github.com/multiversx/mx-sdk-go/blockchain/cryptoProvider"
 	"github.com/multiversx/mx-sdk-go/builders"
@@ -45,12 +46,22 @@ func CreateTxSender(wallet core.CryptoComponentsHolder, cfg TxSenderConfig) (*tx
 		return nil, err
 	}
 
+	hasher, err := factory.NewHasher(cfg.Hasher)
+	if err != nil {
+		return nil, err
+	}
+
+	dtaFormatter, err := NewDataFormatter(hasher)
+	if err != nil {
+		return nil, err
+	}
+
 	return NewTxSender(TxSenderArgs{
 		Wallet:            wallet,
 		Proxy:             proxy,
 		TxInteractor:      ti,
 		TxNonceHandler:    nonceHandler,
-		DataFormatter:     NewDataFormatter(),
+		DataFormatter:     dtaFormatter,
 		SCMultisigAddress: cfg.MultisigSCAddress,
 		SCEsdtSafeAddress: cfg.EsdtSafeSCAddress,
 	})

--- a/server/txSender/txSender.go
+++ b/server/txSender/txSender.go
@@ -121,7 +121,7 @@ func (ts *txSender) createAndSendTxs(ctx context.Context, data *sovereign.Bridge
 				Version:  ts.netConfigs.MinTransactionVersion,
 			}
 		default:
-			log.Error("invalid tx data received", "data", string(tx.Data))
+			log.Error("invalid tx data received", "data", string(txData))
 		}
 
 		err := ts.txNonceHandler.ApplyNonceAndGasPrice(ctx, ts.wallet.GetAddressHandler(), tx)

--- a/testscommon/hasherMock.go
+++ b/testscommon/hasherMock.go
@@ -1,0 +1,31 @@
+package testscommon
+
+// HasherMock -
+type HasherMock struct {
+	ComputeCalled   func(s string) []byte
+	EmptyHashCalled func() []byte
+	SizeCalled      func() int
+}
+
+// Compute -
+func (mock *HasherMock) Compute(s string) []byte {
+	if mock.ComputeCalled != nil {
+		return mock.ComputeCalled(s)
+	}
+
+	return nil
+}
+
+// Size -
+func (mock *HasherMock) Size() int {
+	if mock.SizeCalled != nil {
+		return mock.SizeCalled()
+	}
+
+	return 0
+}
+
+// IsInterfaceNil -
+func (mock *HasherMock) IsInterfaceNil() bool {
+	return mock == nil
+}


### PR DESCRIPTION
In case of unconfirmed operations sent by validators, we only need to send the execute transaction, without register transactions, since those registrations have been already sent before.

This decision of checking if we should send both execute+register is done by checking if the hashOfHashes/parentHash matches all the hashes received to bridge.