### PR TITLE
Bridge data with type

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,13 +6,12 @@ require (
 	github.com/gin-gonic/gin v1.9.1
 	github.com/gorilla/websocket v1.5.0
 	github.com/joho/godotenv v1.5.1
-	github.com/multiversx/mx-chain-core-go v1.2.24-0.20250113143225-72ba2e508401
+	github.com/multiversx/mx-chain-core-go v1.2.25-0.20250219094226-05f41be8a964
 	github.com/multiversx/mx-chain-crypto-go v1.2.11
 	github.com/multiversx/mx-chain-go v1.7.12
 	github.com/multiversx/mx-chain-logger-go v1.0.14
 	github.com/multiversx/mx-sdk-go v1.4.4-0.20241105143052-f5830f5b9079
 	github.com/stretchr/testify v1.8.4
-	github.com/tyler-smith/go-bip39 v1.1.0
 	github.com/urfave/cli v1.22.14
 	google.golang.org/grpc v1.60.1
 )
@@ -57,6 +56,7 @@ require (
 	github.com/tklauser/go-sysconf v0.3.4 // indirect
 	github.com/tklauser/numcpus v0.2.1 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
+	github.com/tyler-smith/go-bip39 v1.1.0 // indirect
 	github.com/ugorji/go/codec v1.2.11 // indirect
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect
 	golang.org/x/arch v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -123,8 +123,8 @@ github.com/multiversx/concurrent-map v0.1.4 h1:hdnbM8VE4b0KYJaGY5yJS2aNIW9TFFsUY
 github.com/multiversx/concurrent-map v0.1.4/go.mod h1:8cWFRJDOrWHOTNSqgYCUvwT7c7eFQ4U2vKMOp4A/9+o=
 github.com/multiversx/mx-chain-communication-go v1.0.14 h1:YhAUDjBBpc5h5W0A7LHLXUMIMeCgwgGvkqfAPbFqsno=
 github.com/multiversx/mx-chain-communication-go v1.0.14/go.mod h1:qYCqgk0h+YpcTA84jHIpCBy6UShRwmXzHSCcdfwNrkw=
-github.com/multiversx/mx-chain-core-go v1.2.24-0.20250113143225-72ba2e508401 h1:jMSqlYlzHwbbjYerMGNZtZsm4eZshH3uXW9N8iNbHD0=
-github.com/multiversx/mx-chain-core-go v1.2.24-0.20250113143225-72ba2e508401/go.mod h1:P/YBoFnt25XUaCQ7Q/SD15vhnc9yV5JDhHxyFO9P8Z0=
+github.com/multiversx/mx-chain-core-go v1.2.25-0.20250219094226-05f41be8a964 h1:/5D6STjVscElFtLzJVo/0FGoqQyvF0ZkDPmYGLl7kog=
+github.com/multiversx/mx-chain-core-go v1.2.25-0.20250219094226-05f41be8a964/go.mod h1:P/YBoFnt25XUaCQ7Q/SD15vhnc9yV5JDhHxyFO9P8Z0=
 github.com/multiversx/mx-chain-crypto-go v1.2.11 h1:MNPJoiTJA5/tedYrI0N22OorbsKDESWG0SF8MCJwcJI=
 github.com/multiversx/mx-chain-crypto-go v1.2.11/go.mod h1:pcZutPdfLiAFytzCU3LxU3s8cXkvpNqquyitFSfoF3o=
 github.com/multiversx/mx-chain-go v1.7.12 h1:cQ3g5sFZEcQmIRwi/wt+K/3d5nIwCMQRC1ZnJDRuRY4=

--- a/server/cmd/server/.env
+++ b/server/cmd/server/.env
@@ -12,6 +12,8 @@ MULTIVERSX_PROXY="https://testnet-gateway.multiversx.com"
 HEADER_VERIFIER_SC_ADDRESS="erd1spyavw0956vq68xj8y4tenjpq2wd5a9p2c6j8gsz7ztyrnpxrruqzu66jx"
 # ESDT Safe address on MultiversX to execute the transactions
 ESDT_SAFE_SC_ADDRESS="erd1spyavw0956vq68xj8y4tenjpq2wd5a9p2c6j8gsz7ztyrnpxrruqzu66jx"
+# Change epoch validators set address on MultiversX to execute the transactions
+CHANGE_VALIDATORS_SC_ADDRESS="erd1spyavw0956vq68xj8y4tenjpq2wd5a9p2c6j8gsz7ztyrnpxrruqzu66jx"
 # Interval in milliseconds between sending bridge txs
 INTERVAL_TO_SEND=1
 # Server certificate for tls secured connection with clients.

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -37,16 +37,17 @@ const (
 )
 
 const (
-	envGRPCPort             = "GRPC_PORT"
-	envWallet               = "WALLET_PATH"
-	envPassword             = "WALLET_PASSWORD"
-	envHeaderVerifierSCAddr = "HEADER_VERIFIER_SC_ADDRESS"
-	envEsdtSafeSCAddr       = "ESDT_SAFE_SC_ADDRESS"
-	envMultiversXProxy      = "MULTIVERSX_PROXY"
-	envIntervalToSend       = "INTERVAL_TO_SEND"
-	envCertFile             = "CERT_FILE"
-	envCertPkFile           = "CERT_PK_FILE"
-	envHasher               = "HASHER"
+	envGRPCPort               = "GRPC_PORT"
+	envWallet                 = "WALLET_PATH"
+	envPassword               = "WALLET_PASSWORD"
+	envHeaderVerifierSCAddr   = "HEADER_VERIFIER_SC_ADDRESS"
+	envEsdtSafeSCAddr         = "ESDT_SAFE_SC_ADDRESS"
+	envChangeValidatorsSCAddr = "CHANGE_VALIDATORS_SC_ADDRESS"
+	envMultiversXProxy        = "MULTIVERSX_PROXY"
+	envIntervalToSend         = "INTERVAL_TO_SEND"
+	envCertFile               = "CERT_FILE"
+	envCertPkFile             = "CERT_PK_FILE"
+	envHasher                 = "HASHER"
 )
 
 func main() {
@@ -144,6 +145,8 @@ func loadConfig() (*config.ServerConfig, error) {
 	walletPassword := os.Getenv(envPassword)
 	headerVerifierSCAddress := os.Getenv(envHeaderVerifierSCAddr)
 	esdtSafeSCAddress := os.Getenv(envEsdtSafeSCAddr)
+	changeValidatorsSCAddress := os.Getenv(envChangeValidatorsSCAddr)
+
 	proxy := os.Getenv(envMultiversXProxy)
 	intervalToSendStr := os.Getenv(envIntervalToSend)
 	certFile := os.Getenv(envCertFile)
@@ -158,6 +161,7 @@ func loadConfig() (*config.ServerConfig, error) {
 	log.Info("loaded config", "grpc port", grpcPort)
 	log.Info("loaded config", "headerVerifierSCAddress", headerVerifierSCAddress)
 	log.Info("loaded config", "esdtSafeSCAddress", esdtSafeSCAddress)
+	log.Info("loaded config", "changeValidatorsSCAddress", changeValidatorsSCAddress)
 	log.Info("loaded config", "proxy", proxy)
 	log.Info("loaded config", "intervalToSend", intervalToSend)
 	log.Info("loaded config", "hasher", hasher)
@@ -172,11 +176,12 @@ func loadConfig() (*config.ServerConfig, error) {
 			Password: walletPassword,
 		},
 		TxSenderConfig: txSender.TxSenderConfig{
-			HeaderVerifierSCAddress: headerVerifierSCAddress,
-			EsdtSafeSCAddress:       esdtSafeSCAddress,
-			Proxy:                   proxy,
-			IntervalToSend:          intervalToSend,
-			Hasher:                  hasher,
+			HeaderVerifierSCAddress:   headerVerifierSCAddress,
+			EsdtSafeSCAddress:         esdtSafeSCAddress,
+			ChangeValidatorsSCAddress: changeValidatorsSCAddress,
+			Proxy:                     proxy,
+			IntervalToSend:            intervalToSend,
+			Hasher:                    hasher,
 		},
 		CertificateConfig: cert.FileCfg{
 			CertFile: certFile,

--- a/server/txSender/config.go
+++ b/server/txSender/config.go
@@ -8,9 +8,10 @@ type WalletConfig struct {
 
 // TxSenderConfig holds tx sender config
 type TxSenderConfig struct {
-	HeaderVerifierSCAddress string
-	EsdtSafeSCAddress       string
-	Proxy                   string
-	IntervalToSend          int
-	Hasher                  string
+	HeaderVerifierSCAddress   string
+	EsdtSafeSCAddress         string
+	ChangeValidatorsSCAddress string
+	Proxy                     string
+	IntervalToSend            int
+	Hasher                    string
 }

--- a/server/txSender/dataFormatter.go
+++ b/server/txSender/dataFormatter.go
@@ -8,11 +8,6 @@ import (
 	"github.com/multiversx/mx-chain-core-go/hashing"
 )
 
-const (
-	registerBridgeOpsPrefix = "registerBridgeOps"
-	executeBridgeOpsPrefix  = "executeBridgeOps"
-)
-
 type dataFormatter struct {
 	dataFormatterHandlers map[int32]txDataFormatter
 }

--- a/server/txSender/dataFormatterDepositTokens.go
+++ b/server/txSender/dataFormatterDepositTokens.go
@@ -1,0 +1,67 @@
+package txSender
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/hex"
+
+	"github.com/multiversx/mx-chain-core-go/data/sovereign"
+	"github.com/multiversx/mx-chain-core-go/hashing"
+)
+
+type dataFormatterDepositTokens struct {
+	hasher hashing.Hasher
+}
+
+func (df *dataFormatterDepositTokens) createTxsData(bridgeData *sovereign.BridgeOutGoingData) ([][]byte, error) {
+	txsData := make([][]byte, 0)
+	registerBridgeOpData := df.createRegisterBridgeOperationsData(bridgeData)
+	if len(registerBridgeOpData) != 0 {
+		txsData = append(txsData, registerBridgeOpData)
+	}
+
+	return append(txsData, createBridgeOperationsData(bridgeData.Hash, bridgeData.OutGoingOperations)...), nil
+}
+
+func (df *dataFormatterDepositTokens) createRegisterBridgeOperationsData(bridgeData *sovereign.BridgeOutGoingData) []byte {
+	hashes := make([]byte, 0)
+	hashesHexEncodedArgs := make([]byte, 0)
+	for _, operation := range bridgeData.OutGoingOperations {
+		hashesHexEncodedArgs = append(hashesHexEncodedArgs, "@"+hex.EncodeToString(operation.Hash)...)
+		hashes = append(hashes, operation.Hash...)
+	}
+
+	// unconfirmed operation, should not register it, only resend it
+	computedHashOfHashes := df.hasher.Compute(string(hashes))
+	if !bytes.Equal(bridgeData.Hash, computedHashOfHashes) {
+		return nil
+	}
+
+	registerBridgeOpData := []byte(registerBridgeOpsPrefix +
+		"@" + hex.EncodeToString(bridgeData.AggregatedSignature) +
+		"@" + hex.EncodeToString(bridgeData.Hash) +
+		"@" + hex.EncodeToString(bridgeData.PubKeysBitmap) +
+		"@" + hex.EncodeToString(uint32ToBytes(bridgeData.Epoch)))
+
+	return append(registerBridgeOpData, hashesHexEncodedArgs...)
+}
+
+func uint32ToBytes(value uint32) []byte {
+	buff := make([]byte, 4)
+	binary.BigEndian.PutUint32(buff, value)
+	return buff
+}
+
+func createBridgeOperationsData(hashOfHashes []byte, outGoingOperations []*sovereign.OutGoingOperation) [][]byte {
+	executeBridgeOpsTxData := make([][]byte, 0)
+	for _, operation := range outGoingOperations {
+		bridgeOpTxData := []byte(
+			executeBridgeOpsPrefix +
+				"@" + hex.EncodeToString(hashOfHashes) +
+				"@" + hex.EncodeToString(operation.Data))
+
+		executeBridgeOpsTxData = append(executeBridgeOpsTxData, bridgeOpTxData)
+	}
+
+	return executeBridgeOpsTxData
+}

--- a/server/txSender/dataFormatterDepositTokens.go
+++ b/server/txSender/dataFormatterDepositTokens.go
@@ -9,6 +9,11 @@ import (
 	"github.com/multiversx/mx-chain-core-go/hashing"
 )
 
+const (
+	registerBridgeOpsPrefix = "registerBridgeOps"
+	executeBridgeOpsPrefix  = "executeBridgeOps"
+)
+
 type dataFormatterDepositTokens struct {
 	hasher hashing.Hasher
 }
@@ -20,7 +25,7 @@ func (df *dataFormatterDepositTokens) createTxsData(bridgeData *sovereign.Bridge
 		txsData = append(txsData, registerBridgeOpData)
 	}
 
-	return append(txsData, createBridgeOperationsData(bridgeData.Hash, bridgeData.OutGoingOperations)...), nil
+	return append(txsData, createExecuteBridgeOperationsData(bridgeData.Hash, bridgeData.OutGoingOperations)...), nil
 }
 
 func (df *dataFormatterDepositTokens) createRegisterBridgeOperationsData(bridgeData *sovereign.BridgeOutGoingData) []byte {
@@ -52,7 +57,7 @@ func uint32ToBytes(value uint32) []byte {
 	return buff
 }
 
-func createBridgeOperationsData(hashOfHashes []byte, outGoingOperations []*sovereign.OutGoingOperation) [][]byte {
+func createExecuteBridgeOperationsData(hashOfHashes []byte, outGoingOperations []*sovereign.OutGoingOperation) [][]byte {
 	executeBridgeOpsTxData := make([][]byte, 0)
 	for _, operation := range outGoingOperations {
 		bridgeOpTxData := []byte(

--- a/server/txSender/dataFormatterValidatorSetChange.go
+++ b/server/txSender/dataFormatterValidatorSetChange.go
@@ -32,9 +32,9 @@ func (df *dataFormatterValidatorSetChange) createTxsData(bridgeData *sovereign.B
 	}
 
 	txData := []byte(changeValidatorSetPrefix +
+		"@" + hex.EncodeToString(bridgeData.AggregatedSignature) +
 		"@" + hex.EncodeToString(bridgeData.Hash) +
 		"@" + hex.EncodeToString(bridgeData.OutGoingOperations[0].Hash) +
-		"@" + hex.EncodeToString(bridgeData.AggregatedSignature) +
 		"@" + hex.EncodeToString(bridgeData.PubKeysBitmap) +
 		"@" + hex.EncodeToString(uint32ToBytes(bridgeData.Epoch)))
 

--- a/server/txSender/dataFormatterValidatorSetChange.go
+++ b/server/txSender/dataFormatterValidatorSetChange.go
@@ -1,0 +1,59 @@
+package txSender
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/multiversx/mx-chain-core-go/data/sovereign"
+)
+
+const changeValidatorSetPrefix = "changeValidatorSet"
+
+type dataFormatterValidatorSetChange struct {
+}
+
+func newDataFormatterValidatorSetChange() *dataFormatterValidatorSetChange {
+	return &dataFormatterValidatorSetChange{}
+}
+
+// createValidatorSetChangeData will format the data to the following format:
+//
+// changeValidatorSet@HashOfHashes@HashOfOperation@AggregatedBLSMultiSig@PubKeysBitMap@Epoch@list<allKeyIDsInNewEpoch>
+func (df *dataFormatterValidatorSetChange) createValidatorSetChangeData(bridgeData *sovereign.BridgeOutGoingData) ([]byte, error) {
+	numOutGoingOperations := len(bridgeData.OutGoingOperations)
+	if numOutGoingOperations != 1 {
+		return nil, fmt.Errorf("%w, expected 1, got %d", errInvalidBridgeDataSetValidatorChange, numOutGoingOperations)
+	}
+
+	pubKeys, err := df.formatPubKeys(bridgeData.OutGoingOperations[0].Data)
+	if err != nil {
+		return nil, err
+	}
+
+	txData := []byte(changeValidatorSetPrefix +
+		"@" + hex.EncodeToString(bridgeData.Hash) +
+		"@" + hex.EncodeToString(bridgeData.OutGoingOperations[0].Hash) +
+		"@" + hex.EncodeToString(bridgeData.AggregatedSignature) +
+		"@" + hex.EncodeToString(bridgeData.PubKeysBitmap) +
+		"@" + hex.EncodeToString(uint32ToBytes(bridgeData.Epoch)))
+
+	return append(txData, pubKeys...), nil
+}
+
+func (df *dataFormatterValidatorSetChange) formatPubKeys(data []byte) ([]byte, error) {
+	pubKeysBridgeData := &sovereign.BridgeOutGoingDataValidatorSetChange{
+		PubKeyIDs: make([][]byte, 0),
+	}
+	err := proto.Unmarshal(data, pubKeysBridgeData)
+	if err != nil {
+		return nil, err
+	}
+
+	pubKeysHex := make([]byte, 0, len(pubKeysBridgeData.PubKeyIDs))
+	for _, pubKey := range pubKeysBridgeData.PubKeyIDs {
+		pubKeysHex = append(pubKeysHex, "@"+hex.EncodeToString(pubKey)...)
+	}
+
+	return pubKeysHex, nil
+}

--- a/server/txSender/dataFormatterValidatorSetChange.go
+++ b/server/txSender/dataFormatterValidatorSetChange.go
@@ -17,16 +17,16 @@ func newDataFormatterValidatorSetChange() *dataFormatterValidatorSetChange {
 	return &dataFormatterValidatorSetChange{}
 }
 
-// createValidatorSetChangeData will format the data to the following format:
+// createTxsData will format the data to the following format:
 //
 // changeValidatorSet@HashOfHashes@HashOfOperation@AggregatedBLSMultiSig@PubKeysBitMap@Epoch@list<allKeyIDsInNewEpoch>
-func (df *dataFormatterValidatorSetChange) createValidatorSetChangeData(bridgeData *sovereign.BridgeOutGoingData) ([]byte, error) {
+func (df *dataFormatterValidatorSetChange) createTxsData(bridgeData *sovereign.BridgeOutGoingData) ([][]byte, error) {
 	numOutGoingOperations := len(bridgeData.OutGoingOperations)
 	if numOutGoingOperations != 1 {
 		return nil, fmt.Errorf("%w, expected 1, got %d", errInvalidBridgeDataSetValidatorChange, numOutGoingOperations)
 	}
 
-	pubKeys, err := df.formatPubKeys(bridgeData.OutGoingOperations[0].Data)
+	pubKeys, err := formatPubKeys(bridgeData.OutGoingOperations[0].Data)
 	if err != nil {
 		return nil, err
 	}
@@ -38,10 +38,10 @@ func (df *dataFormatterValidatorSetChange) createValidatorSetChangeData(bridgeDa
 		"@" + hex.EncodeToString(bridgeData.PubKeysBitmap) +
 		"@" + hex.EncodeToString(uint32ToBytes(bridgeData.Epoch)))
 
-	return append(txData, pubKeys...), nil
+	return [][]byte{append(txData, pubKeys...)}, nil
 }
 
-func (df *dataFormatterValidatorSetChange) formatPubKeys(data []byte) ([]byte, error) {
+func formatPubKeys(data []byte) ([]byte, error) {
 	pubKeysBridgeData := &sovereign.BridgeOutGoingDataValidatorSetChange{
 		PubKeyIDs: make([][]byte, 0),
 	}

--- a/server/txSender/dataFormatterValidatorSetChange.go
+++ b/server/txSender/dataFormatterValidatorSetChange.go
@@ -4,8 +4,8 @@ import (
 	"encoding/hex"
 	"fmt"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/multiversx/mx-chain-core-go/data/sovereign"
+	"google.golang.org/protobuf/proto"
 )
 
 const changeValidatorSetPrefix = "changeValidatorSet"

--- a/server/txSender/dataFormatterValidatorSetChange_test.go
+++ b/server/txSender/dataFormatterValidatorSetChange_test.go
@@ -1,0 +1,51 @@
+package txSender
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/multiversx/mx-chain-core-go/data/block"
+	"github.com/multiversx/mx-chain-core-go/data/sovereign"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateValidatorSetChangeData(t *testing.T) {
+	dataFormatterValidators := newDataFormatterValidatorSetChange()
+
+	pubKey1 := []byte("pk1")
+	pubKey2 := []byte("pk2")
+	validatorPubKeysData := &sovereign.BridgeOutGoingDataValidatorSetChange{
+		PubKeyIDs: [][]byte{pubKey1, pubKey2},
+	}
+	validatorPubKeysDataBytes, err := proto.Marshal(validatorPubKeysData)
+	require.Nil(t, err)
+
+	bridgeData := &sovereign.BridgeOutGoingData{
+		Type: int32(block.OutGoingMbChangeValidatorSet),
+		Hash: []byte("hashOfHashes"),
+		OutGoingOperations: []*sovereign.OutGoingOperation{
+			{
+				Hash: []byte("operationHash"),
+				Data: validatorPubKeysDataBytes,
+			},
+		},
+		AggregatedSignature: []byte("aggregatedSig"),
+		PubKeysBitmap:       []byte("pubKeysBitmap"),
+		Epoch:               4,
+	}
+
+	expectedTxData := []byte(changeValidatorSetPrefix +
+		"@" + hex.EncodeToString([]byte("hashOfHashes")) +
+		"@" + hex.EncodeToString([]byte("operationHash")) +
+		"@" + hex.EncodeToString([]byte("aggregatedSig")) +
+		"@" + hex.EncodeToString([]byte("pubKeysBitmap")) +
+		"@" + "00000004" +
+		"@" + hex.EncodeToString(pubKey1) +
+		"@" + hex.EncodeToString(pubKey2))
+
+	txData, err := dataFormatterValidators.createValidatorSetChangeData(bridgeData)
+	require.Nil(t, err)
+	require.Equal(t, expectedTxData, txData)
+}

--- a/server/txSender/dataFormatterValidatorSetChange_test.go
+++ b/server/txSender/dataFormatterValidatorSetChange_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCreateValidatorSetChangeData(t *testing.T) {
+func TestDataFormatterValidatorSetChange_createTxsData(t *testing.T) {
 	dataFormatterValidators := newDataFormatterValidatorSetChange()
 
 	pubKey1 := []byte("pk1")
@@ -45,7 +45,7 @@ func TestCreateValidatorSetChangeData(t *testing.T) {
 		"@" + hex.EncodeToString(pubKey1) +
 		"@" + hex.EncodeToString(pubKey2))
 
-	txData, err := dataFormatterValidators.createValidatorSetChangeData(bridgeData)
+	txData, err := dataFormatterValidators.createTxsData(bridgeData)
 	require.Nil(t, err)
-	require.Equal(t, expectedTxData, txData)
+	require.Equal(t, [][]byte{expectedTxData}, txData)
 }

--- a/server/txSender/dataFormatterValidatorSetChange_test.go
+++ b/server/txSender/dataFormatterValidatorSetChange_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestDataFormatterValidatorSetChange_createTxsData(t *testing.T) {
+	t.Parallel()
+
 	dataFormatterValidators := newDataFormatterValidatorSetChange()
 
 	pubKey1 := []byte("pk1")
@@ -48,4 +50,41 @@ func TestDataFormatterValidatorSetChange_createTxsData(t *testing.T) {
 	txData, err := dataFormatterValidators.createTxsData(bridgeData)
 	require.Nil(t, err)
 	require.Equal(t, [][]byte{expectedTxData}, txData)
+}
+
+func TestDataFormatterValidatorSetChange_createTxsDataErrorCases(t *testing.T) {
+	t.Parallel()
+
+	dataFormatterValidators := newDataFormatterValidatorSetChange()
+
+	t.Run("invalid num of out going operations", func(t *testing.T) {
+		bridgeData := &sovereign.BridgeOutGoingData{
+			OutGoingOperations: []*sovereign.OutGoingOperation{
+				{
+					Data: []byte("data1"),
+				},
+				{
+					Data: []byte("data2"),
+				},
+			},
+		}
+
+		txData, err := dataFormatterValidators.createTxsData(bridgeData)
+		require.ErrorIs(t, err, errInvalidBridgeDataSetValidatorChange)
+		require.Nil(t, txData)
+	})
+
+	t.Run("invalid data in out going operation", func(t *testing.T) {
+		bridgeData := &sovereign.BridgeOutGoingData{
+			OutGoingOperations: []*sovereign.OutGoingOperation{
+				{
+					Data: []byte("invalid data"),
+				},
+			},
+		}
+
+		txData, err := dataFormatterValidators.createTxsData(bridgeData)
+		require.NotNil(t, err)
+		require.Nil(t, txData)
+	})
 }

--- a/server/txSender/dataFormatterValidatorSetChange_test.go
+++ b/server/txSender/dataFormatterValidatorSetChange_test.go
@@ -39,9 +39,9 @@ func TestDataFormatterValidatorSetChange_createTxsData(t *testing.T) {
 	}
 
 	expectedTxData := []byte(changeValidatorSetPrefix +
+		"@" + hex.EncodeToString([]byte("aggregatedSig")) +
 		"@" + hex.EncodeToString([]byte("hashOfHashes")) +
 		"@" + hex.EncodeToString([]byte("operationHash")) +
-		"@" + hex.EncodeToString([]byte("aggregatedSig")) +
 		"@" + hex.EncodeToString([]byte("pubKeysBitmap")) +
 		"@" + "00000004" +
 		"@" + hex.EncodeToString(pubKey1) +

--- a/server/txSender/dataFormatterValidatorSetChange_test.go
+++ b/server/txSender/dataFormatterValidatorSetChange_test.go
@@ -4,9 +4,9 @@ import (
 	"encoding/hex"
 	"testing"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/multiversx/mx-chain-core-go/data/block"
 	"github.com/multiversx/mx-chain-core-go/data/sovereign"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/stretchr/testify/require"
 )

--- a/server/txSender/errors.go
+++ b/server/txSender/errors.go
@@ -18,6 +18,8 @@ var errNoHeaderVerifierSCAddress = errors.New("no header verifier sc address pro
 
 var errNoEsdtSafeSCAddress = errors.New("no esdt safe sc address provided")
 
+var errNoChangeValidatorSetSCAddress = errors.New("no change validator set sc address provided")
+
 var errInvalidBridgeDataSetValidatorChange = errors.New("invalid number of bridge data operations for validator set change")
 
 var errInvalidTxDataPrefix = errors.New("invalid/unknown tx data prefix")

--- a/server/txSender/errors.go
+++ b/server/txSender/errors.go
@@ -22,4 +22,4 @@ var errNoChangeValidatorSetSCAddress = errors.New("no change validator set sc ad
 
 var errInvalidBridgeDataSetValidatorChange = errors.New("invalid number of bridge data operations for validator set change")
 
-var errInvalidTxDataPrefix = errors.New("invalid/unknown tx data prefix")
+var errInvalidTxDataPrefix = errors.New("invalid/unknown tx data endpoint to call")

--- a/server/txSender/errors.go
+++ b/server/txSender/errors.go
@@ -19,3 +19,5 @@ var errNoHeaderVerifierSCAddress = errors.New("no header verifier sc address pro
 var errNoEsdtSafeSCAddress = errors.New("no esdt safe sc address provided")
 
 var errInvalidBridgeDataSetValidatorChange = errors.New("invalid number of bridge data operations for validator set change")
+
+var errInvalidTxDataPrefix = errors.New("invalid/unknown tx data prefix")

--- a/server/txSender/errors.go
+++ b/server/txSender/errors.go
@@ -17,3 +17,5 @@ var errNilNonceHandler = errors.New("nil nonce handler provided")
 var errNoHeaderVerifierSCAddress = errors.New("no header verifier sc address provided")
 
 var errNoEsdtSafeSCAddress = errors.New("no esdt safe sc address provided")
+
+var errInvalidBridgeDataSetValidatorChange = errors.New("invalid number of bridge data operations for validator set change")

--- a/server/txSender/factory.go
+++ b/server/txSender/factory.go
@@ -57,12 +57,13 @@ func CreateTxSender(wallet core.CryptoComponentsHolder, cfg TxSenderConfig) (*tx
 	}
 
 	return NewTxSender(TxSenderArgs{
-		Wallet:                  wallet,
-		Proxy:                   proxy,
-		TxInteractor:            ti,
-		TxNonceHandler:          nonceHandler,
-		DataFormatter:           dtaFormatter,
-		SCHeaderVerifierAddress: cfg.HeaderVerifierSCAddress,
-		SCEsdtSafeAddress:       cfg.EsdtSafeSCAddress,
+		Wallet:                    wallet,
+		Proxy:                     proxy,
+		TxInteractor:              ti,
+		TxNonceHandler:            nonceHandler,
+		DataFormatter:             dtaFormatter,
+		SCHeaderVerifierAddress:   cfg.HeaderVerifierSCAddress,
+		SCEsdtSafeAddress:         cfg.EsdtSafeSCAddress,
+		SCChangeValidatorsAddress: cfg.ChangeValidatorsSCAddress,
 	})
 }

--- a/server/txSender/interface.go
+++ b/server/txSender/interface.go
@@ -34,3 +34,7 @@ type TxNonceSenderHandler interface {
 	SendTransactions(ctx context.Context, txs ...*transaction.FrontendTransaction) ([]string, error)
 	IsInterfaceNil() bool
 }
+
+type txDataFormatter interface {
+	createTxsData(bridgeData *sovereign.BridgeOutGoingData) ([][]byte, error)
+}

--- a/server/txSender/txSender.go
+++ b/server/txSender/txSender.go
@@ -2,6 +2,7 @@ package txSender
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/multiversx/mx-chain-core-go/core/check"
@@ -22,14 +23,17 @@ type TxSenderArgs struct {
 	SCEsdtSafeAddress       string
 }
 
+type txConfig struct {
+	receiver string
+}
+
 type txSender struct {
-	wallet                  core.CryptoComponentsHolder
-	netConfigs              *data.NetworkConfig
-	txInteractor            TxInteractor
-	txNonceHandler          TxNonceSenderHandler
-	dataFormatter           DataFormatter
-	scHeaderVerifierAddress string
-	scEsdtSafeAddress       string
+	wallet         core.CryptoComponentsHolder
+	netConfigs     *data.NetworkConfig
+	txInteractor   TxInteractor
+	txNonceHandler TxNonceSenderHandler
+	dataFormatter  DataFormatter
+	txConfigs      map[string]*txConfig
 }
 
 // NewTxSender creates a new tx sender
@@ -45,13 +49,15 @@ func NewTxSender(args TxSenderArgs) (*txSender, error) {
 	}
 
 	return &txSender{
-		wallet:                  args.Wallet,
-		netConfigs:              networkConfig,
-		txInteractor:            args.TxInteractor,
-		txNonceHandler:          args.TxNonceHandler,
-		dataFormatter:           args.DataFormatter,
-		scHeaderVerifierAddress: args.SCHeaderVerifierAddress,
-		scEsdtSafeAddress:       args.SCEsdtSafeAddress,
+		wallet:         args.Wallet,
+		netConfigs:     networkConfig,
+		txInteractor:   args.TxInteractor,
+		txNonceHandler: args.TxNonceHandler,
+		dataFormatter:  args.DataFormatter,
+		txConfigs: map[string]*txConfig{
+			registerBridgeOpsPrefix: {receiver: args.SCHeaderVerifierAddress},
+			executeBridgeOpsPrefix:  {receiver: args.SCEsdtSafeAddress},
+		},
 	}, nil
 }
 
@@ -95,37 +101,23 @@ func (ts *txSender) createAndSendTxs(ctx context.Context, data *sovereign.Bridge
 	txsData := ts.dataFormatter.CreateTxsData(data)
 
 	for _, txData := range txsData {
-		var tx *coreTx.FrontendTransaction
+		tx := &coreTx.FrontendTransaction{
+			Value:    "0",
+			Sender:   ts.wallet.GetBech32(),
+			GasPrice: ts.netConfigs.MinGasPrice,
+			GasLimit: 50_000_000, // todo
+			Data:     txData,
+			ChainID:  ts.netConfigs.ChainID,
+			Version:  ts.netConfigs.MinTransactionVersion,
+		}
 
-		switch {
-		case strings.HasPrefix(string(txData), registerBridgeOpsPrefix):
-			tx = &coreTx.FrontendTransaction{
-				Value:    "0",
-				Receiver: ts.scHeaderVerifierAddress,
-				Sender:   ts.wallet.GetBech32(),
-				GasPrice: ts.netConfigs.MinGasPrice,
-				GasLimit: 50_000_000, // todo
-				Data:     txData,
-				ChainID:  ts.netConfigs.ChainID,
-				Version:  ts.netConfigs.MinTransactionVersion,
-			}
-		case strings.HasPrefix(string(txData), executeBridgeOpsPrefix):
-			tx = &coreTx.FrontendTransaction{
-				Value:    "0",
-				Receiver: ts.scEsdtSafeAddress,
-				Sender:   ts.wallet.GetBech32(),
-				GasPrice: ts.netConfigs.MinGasPrice,
-				GasLimit: 50_000_000, // todo
-				Data:     txData,
-				ChainID:  ts.netConfigs.ChainID,
-				Version:  ts.netConfigs.MinTransactionVersion,
-			}
-		default:
-			log.Error("invalid tx data received", "data", string(txData))
+		err := ts.setTxFields(txData, tx)
+		if err != nil {
+			log.Error("invalid tx data received", "data", string(txData), "error", err)
 			continue
 		}
 
-		err := ts.txNonceHandler.ApplyNonceAndGasPrice(ctx, tx)
+		err = ts.txNonceHandler.ApplyNonceAndGasPrice(ctx, tx)
 		if err != nil {
 			return nil, err
 		}
@@ -145,6 +137,22 @@ func (ts *txSender) createAndSendTxs(ctx context.Context, data *sovereign.Bridge
 	}
 
 	return txHashes, nil
+}
+
+func (ts *txSender) setTxFields(txData []byte, tx *coreTx.FrontendTransaction) error {
+	prefixID := getTxDataPrefix(txData)
+	txCfg, found := ts.txConfigs[prefixID]
+	if !found {
+		return fmt.Errorf("%w, prefix = %s", errInvalidTxDataPrefix, prefixID)
+	}
+
+	tx.Receiver = txCfg.receiver
+	return nil
+}
+
+func getTxDataPrefix(txData []byte) string {
+	prefix := strings.Split(string(txData), "@")
+	return prefix[0]
 }
 
 // IsInterfaceNil checks if the underlying pointer is nil

--- a/server/txSender/txSender.go
+++ b/server/txSender/txSender.go
@@ -14,13 +14,14 @@ import (
 
 // TxSenderArgs holds args to create a new tx sender
 type TxSenderArgs struct {
-	Wallet                  core.CryptoComponentsHolder
-	Proxy                   Proxy
-	TxInteractor            TxInteractor
-	TxNonceHandler          TxNonceSenderHandler
-	DataFormatter           DataFormatter
-	SCHeaderVerifierAddress string
-	SCEsdtSafeAddress       string
+	Wallet                    core.CryptoComponentsHolder
+	Proxy                     Proxy
+	TxInteractor              TxInteractor
+	TxNonceHandler            TxNonceSenderHandler
+	DataFormatter             DataFormatter
+	SCHeaderVerifierAddress   string
+	SCEsdtSafeAddress         string
+	SCChangeValidatorsAddress string
 }
 
 type txConfig struct {
@@ -55,8 +56,9 @@ func NewTxSender(args TxSenderArgs) (*txSender, error) {
 		txNonceHandler: args.TxNonceHandler,
 		dataFormatter:  args.DataFormatter,
 		txConfigs: map[string]*txConfig{
-			registerBridgeOpsPrefix: {receiver: args.SCHeaderVerifierAddress},
-			executeBridgeOpsPrefix:  {receiver: args.SCEsdtSafeAddress},
+			registerBridgeOpsPrefix:  {receiver: args.SCHeaderVerifierAddress},
+			executeBridgeOpsPrefix:   {receiver: args.SCEsdtSafeAddress},
+			changeValidatorSetPrefix: {receiver: args.SCChangeValidatorsAddress},
 		},
 	}, nil
 }
@@ -82,6 +84,9 @@ func checkArgs(args TxSenderArgs) error {
 	}
 	if len(args.SCEsdtSafeAddress) == 0 {
 		return errNoEsdtSafeSCAddress
+	}
+	if len(args.SCChangeValidatorsAddress) == 0 {
+		return errNoChangeValidatorSetSCAddress
 	}
 
 	return nil

--- a/server/txSender/txSender_test.go
+++ b/server/txSender/txSender_test.go
@@ -16,19 +16,21 @@ import (
 )
 
 const (
-	scHeaderVerifierAddress = "erd1qqq"
-	scEsdtSafeAddress       = "erd1qqqe"
+	scHeaderVerifierAddress      = "erd1qqq"
+	scEsdtSafeAddress            = "erd1qqqe"
+	scChangeValidatorsSetAddress = "erd1qqqw"
 )
 
 func createArgs() TxSenderArgs {
 	return TxSenderArgs{
-		Wallet:                  &testscommon.CryptoComponentsHolderMock{},
-		Proxy:                   &testscommon.ProxyMock{},
-		TxInteractor:            &testscommon.TxInteractorMock{},
-		DataFormatter:           &testscommon.DataFormatterMock{},
-		TxNonceHandler:          &testscommon.TxNonceSenderHandlerMock{},
-		SCHeaderVerifierAddress: scHeaderVerifierAddress,
-		SCEsdtSafeAddress:       scEsdtSafeAddress,
+		Wallet:                    &testscommon.CryptoComponentsHolderMock{},
+		Proxy:                     &testscommon.ProxyMock{},
+		TxInteractor:              &testscommon.TxInteractorMock{},
+		DataFormatter:             &testscommon.DataFormatterMock{},
+		TxNonceHandler:            &testscommon.TxNonceSenderHandlerMock{},
+		SCHeaderVerifierAddress:   scHeaderVerifierAddress,
+		SCEsdtSafeAddress:         scEsdtSafeAddress,
+		SCChangeValidatorsAddress: scChangeValidatorsSetAddress,
 	}
 }
 

--- a/server/txSender/txSender_test.go
+++ b/server/txSender/txSender_test.go
@@ -84,9 +84,9 @@ func TestTxSender_SendTxs(t *testing.T) {
 	expectedDataIdx := 0
 	expectedTxHashes := []string{"txHash1", "txHash2", "txHash3"}
 	expectedTxsData := [][]byte{
-		[]byte(registerBridgeOpsPrefix + "txData1"),
-		[]byte(executeBridgeOpsPrefix + "txData2"),
-		[]byte(executeBridgeOpsPrefix + "txData3"),
+		[]byte(registerBridgeOpsPrefix + "@" + "txData1"),
+		[]byte(executeBridgeOpsPrefix + "@" + "txData2"),
+		[]byte(executeBridgeOpsPrefix + "@" + "txData3"),
 	}
 	expectedTxsReceiver := []string{
 		scHeaderVerifierAddress,
@@ -192,7 +192,7 @@ func TestTxSender_SendTxsConcurrently(t *testing.T) {
 
 	args.DataFormatter = &testscommon.DataFormatterMock{
 		CreateTxsDataCalled: func(data *sovereign.BridgeOperations) [][]byte {
-			return [][]byte{[]byte(executeBridgeOpsPrefix + "txData")}
+			return [][]byte{[]byte(executeBridgeOpsPrefix + "@" + "txData")}
 		},
 	}
 	args.TxNonceHandler = &testscommon.TxNonceSenderHandlerMock{


### PR DESCRIPTION
Integrate bridge data operation with type
--

- Data formatter & tx sender now contain a map of handlers for different bridge operation types
- New address for change validator set endpoint added in config
- Added support for `changeValidatorSet` data formatter, which will format :
```
changeValidatorSet@HashOfHashes@HashOfOperation@AggregatedBLSMultiSig@PubKeysBitMap@Epoch@list<allKeyIDsInNewEpoch>
```

`Data []byte` from received `BridgeOutGoingData.OutGoingOperation[0]`, will represent the proto marshalled bytes of `BridgeOutGoingDataValidatorSetChange` struct, which contains `PubKeyIDs: make([][]byte, 0)` 